### PR TITLE
Small changes

### DIFF
--- a/addons/zylann.editor_debugger/dock.gd
+++ b/addons/zylann.editor_debugger/dock.gd
@@ -7,8 +7,8 @@ signal node_selected(node)
 
 onready var _popup_menu = get_node("PopupMenu")
 onready var _save_branch_as_scene_button = get_node("PopupMenu/SaveBranchAsSceneButton")
-onready var _inspection_checkbox = get_node("VBoxContainer/ShowInInspectorCheckbox")
-onready var _label = get_node("VBoxContainer/Label")
+onready var _inspection_checkbox = get_node("VBoxContainer/HBoxContainer/InspectCheckbox")
+onready var _label = get_node("VBoxContainer/HBoxContainer/Label")
 onready var _tree_view = get_node("VBoxContainer/Tree")
 onready var _save_branch_file_dialog = get_node("SaveBranchFileDialog")
 

--- a/addons/zylann.editor_debugger/dock.tscn
+++ b/addons/zylann.editor_debugger/dock.tscn
@@ -31,23 +31,31 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="ShowInInspectorCheckbox" type="CheckBox" parent="VBoxContainer"]
-margin_right = 262.0
-margin_bottom = 24.0
-text = "Show in inspector"
-
 [node name="Tree" type="Tree" parent="VBoxContainer"]
-margin_top = 28.0
 margin_right = 262.0
-margin_bottom = 528.0
+margin_bottom = 518.0
 size_flags_vertical = 3
 allow_rmb_select = true
 
-[node name="Label" type="Label" parent="VBoxContainer"]
-margin_top = 532.0
+[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer"]
+margin_top = 522.0
 margin_right = 262.0
 margin_bottom = 546.0
+
+[node name="InspectCheckbox" type="CheckBox" parent="VBoxContainer/HBoxContainer"]
+margin_right = 76.0
+margin_bottom = 24.0
+text = "Inspect"
+
+[node name="Label" type="Label" parent="VBoxContainer/HBoxContainer"]
+margin_left = 80.0
+margin_right = 262.0
+margin_bottom = 24.0
+size_flags_horizontal = 3
+size_flags_vertical = 1
 text = "Hello World"
+align = 2
+valign = 1
 
 [node name="SaveBranchFileDialog" type="FileDialog" parent="."]
 margin_right = 315.0
@@ -55,9 +63,10 @@ margin_bottom = 130.0
 filters = PoolStringArray( "*.tscn ; TSCN", "*.scn ; SCN", "*.res ; RES" )
 current_file = "EditorBranch.tscn"
 current_path = "res://EditorBranch.tscn"
+
 [connection signal="pressed" from="PopupMenu/SaveBranchAsSceneButton" to="." method="_on_SaveBranchAsSceneButton_pressed"]
-[connection signal="toggled" from="VBoxContainer/ShowInInspectorCheckbox" to="." method="_on_ShowInInspectorCheckbox_toggled"]
 [connection signal="item_rmb_selected" from="VBoxContainer/Tree" to="." method="_on_Tree_item_rmb_selected"]
 [connection signal="item_selected" from="VBoxContainer/Tree" to="." method="_on_Tree_item_selected"]
 [connection signal="nothing_selected" from="VBoxContainer/Tree" to="." method="_on_Tree_nothing_selected"]
+[connection signal="toggled" from="VBoxContainer/HBoxContainer/InspectCheckbox" to="." method="_on_ShowInInspectorCheckbox_toggled"]
 [connection signal="file_selected" from="SaveBranchFileDialog" to="." method="_on_SaveBranchFileDialog_file_selected"]

--- a/addons/zylann.editor_debugger/dock.tscn
+++ b/addons/zylann.editor_debugger/dock.tscn
@@ -35,6 +35,7 @@ __meta__ = {
 margin_right = 262.0
 margin_bottom = 518.0
 size_flags_vertical = 3
+allow_reselect = true
 allow_rmb_select = true
 
 [node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer"]

--- a/addons/zylann.editor_debugger/plugin.gd
+++ b/addons/zylann.editor_debugger/plugin.gd
@@ -8,7 +8,7 @@ func _enter_tree():
 	_dock = load("res://addons/zylann.editor_debugger/dock.tscn")
 	_dock = _dock.instance()
 	_dock.connect("node_selected", self, "_on_EditorDebugger_node_selected")
-	add_control_to_dock(DOCK_SLOT_RIGHT_UL, _dock)
+	add_control_to_dock(DOCK_SLOT_RIGHT_BL, _dock)
 	
 	var editor_settings = get_editor_interface().get_editor_settings()
 	editor_settings.connect("settings_changed", self, "_on_EditorSettings_settings_changed")

--- a/addons/zylann.editor_debugger/plugin.gd
+++ b/addons/zylann.editor_debugger/plugin.gd
@@ -10,9 +10,9 @@ func _enter_tree():
 	_dock.connect("node_selected", self, "_on_EditorDebugger_node_selected")
 	add_control_to_dock(DOCK_SLOT_RIGHT_BL, _dock)
 	
-	var editor_settings = get_editor_interface().get_editor_settings()
-	editor_settings.connect("settings_changed", self, "_on_EditorSettings_settings_changed")
-	call_deferred("_on_EditorSettings_settings_changed")
+	# var editor_settings = get_editor_interface().get_editor_settings()
+	# editor_settings.connect("settings_changed", self, "_on_EditorSettings_settings_changed")
+	# call_deferred("_on_EditorSettings_settings_changed")
 
 
 func _exit_tree():
@@ -27,6 +27,8 @@ func _on_EditorDebugger_node_selected(node):
 		get_editor_interface().inspect_object(node)
 
 
+
+# Not connected!
 func _on_EditorSettings_settings_changed():
 	var editor_settings = get_editor_interface().get_editor_settings()
 	

--- a/icon.png.import
+++ b/icon.png.import
@@ -3,6 +3,9 @@
 importer="texture"
 type="StreamTexture"
 path="res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex"
+metadata={
+"vram_texture": false
+}
 
 [deps]
 
@@ -14,6 +17,7 @@ dest_files=[ "res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex" ]
 compress/mode=0
 compress/lossy_quality=0.7
 compress/hdr_mode=0
+compress/bptc_ldr=0
 compress/normal_map=0
 flags/repeat=0
 flags/filter=true
@@ -23,6 +27,8 @@ flags/srgb=2
 process/fix_alpha_border=true
 process/premult_alpha=false
 process/HDR_as_SRGB=false
+process/invert_color=false
+process/normal_map_invert_y=false
 stream=false
 size_limit=0
 detect_3d=true

--- a/project.godot
+++ b/project.godot
@@ -12,7 +12,3 @@ config_version=4
 
 config/name="Editor Debugger"
 config/icon="res://icon.png"
-
-[editor_plugins]
-
-enabled=PoolStringArray( "res://addons/zylann.editor_debugger/plugin.cfg" )

--- a/project.godot
+++ b/project.godot
@@ -6,13 +6,13 @@
 ;   [section] ; section goes between []
 ;   param=value ; assign values to parameters
 
-config_version=3
+config_version=4
 
 [application]
 
 config/name="Editor Debugger"
 config/icon="res://icon.png"
 
-[rendering]
+[editor_plugins]
 
-environment/default_environment="res://default_env.tres"
+enabled=PoolStringArray( "res://addons/zylann.editor_debugger/plugin.cfg" )


### PR DESCRIPTION
1- Updated the project file to 3.4.2, the icon.png.import also got updated - by the Editor.

2- Changed the Dock default position to the Bottom Right dock to be able to Inspect elements while the Inspector is visible.

3- Merged the mouse position label with the Inspect button, and also changed the Checkbox text from "Show In Inspector" to "Inspect" , since it will be in the same HboxContainer with the mouse position label.

4- Enabled allow_reselect in the tree, because when i enable the ShowInInspectorCheckbox i need to select another node and then i reselect the same node again, this will fix the issue by reselecting the same node and it will be visible in inspector.

![image](https://user-images.githubusercontent.com/53877170/151496857-685d0aae-26ba-40f6-a69b-2a0a7e3376d6.png)

