### PR TITLE
Is keyword fix

### DIFF
--- a/addons/zylann.editor_debugger/util.gd
+++ b/addons/zylann.editor_debugger/util.gd
@@ -4,7 +4,7 @@
 static func get_node_in_parents(node: Node, klass) -> Node:
 	while node != null:
 		node = node.get_parent()
-		if node != null and node is klass:
+		if node != null and is_instance_of(node, klass):
 			return node
 	return null
 


### PR DESCRIPTION
The plugin was broken by a change in Godot 4 that the is keyword can only be used to check against pre-compiled classes. I therefore replaced the is keyword with "is_instance_of" method and the plugin is now functional again in 4.0.0 stable