### PR TITLE
Don't redundantly print the node on right click

### DIFF
--- a/addons/zylann.editor_debugger/dock.gd
+++ b/addons/zylann.editor_debugger/dock.gd
@@ -44,6 +44,7 @@ var _control_highlighter: ColorRect = null
 # @see _update_node_view
 var _no_texture := get_theme_icon("", "EditorIcons")
 
+var current_node: Node
 
 func get_tree_view() -> Tree:
 	return _tree_view
@@ -155,8 +156,11 @@ func _update_node_view(node: Node, view: TreeItem) -> void:
 func _select_node() -> void:
 	var node_view := _tree_view.get_selected()
 	var node := _get_node_from_view(node_view)
+
+	if(node != current_node):
+		print("Selected ", node)
 	
-	print("Selected ", node)
+	current_node = node
 	
 	_highlight_node(node)
 	


### PR DESCRIPTION
Before:

https://github.com/Zylann/godot_editor_debugger_plugin/assets/105675984/b396e03a-d095-48d2-98f6-557012c79c13

After: 


https://github.com/Zylann/godot_editor_debugger_plugin/assets/105675984/5e3a602d-42d2-473c-8ff2-82422ba9201b

