### PR TITLE
Use the EditorInterface singleton directly

### DIFF
--- a/addons/zylann.editor_debugger/plugin.gd
+++ b/addons/zylann.editor_debugger/plugin.gd
@@ -25,4 +25,4 @@ func _exit_tree() -> void:
 func _on_EditorDebugger_node_selected(node: Node) -> void:
 	if _dock.is_inspection_enabled():
 		# Oops.
-		get_editor_interface().inspect_object(node)
+		EditorInterface.inspect_object(node)


### PR DESCRIPTION
This PR is mostly for statically typing variables for projects with strict type checking (otherwise they error out due  this plugin).

Also switched [`get_editor_interface()`](https://docs.godotengine.org/en/4.2/classes/class_editorplugin.html#class-editorplugin-method-get-editor-interface) for direct `EditorInterface` access since the getter is deprecated.