### PR TITLE
Fix focusing on ScriptEditor not expanding tree

### DIFF
--- a/addons/zylann.editor_debugger/dock.tscn
+++ b/addons/zylann.editor_debugger/dock.tscn
@@ -36,6 +36,7 @@ filters = PackedStringArray("*.tscn ; TSCN", "*.scn ; SCN", "*.res ; RES")
 
 [connection signal="id_pressed" from="PopupMenu" to="." method="_on_popup_menu_id_pressed"]
 [connection signal="toggled" from="VBoxContainer/ShowInInspectorCheckbox" to="." method="_on_ShowInInspectorCheckbox_toggled"]
+[connection signal="item_collapsed" from="VBoxContainer/Tree" to="." method="_on_tree_item_collapsed"]
 [connection signal="item_mouse_selected" from="VBoxContainer/Tree" to="." method="_on_Tree_item_mouse_selected"]
 [connection signal="item_selected" from="VBoxContainer/Tree" to="." method="_on_Tree_item_selected"]
 [connection signal="nothing_selected" from="VBoxContainer/Tree" to="." method="_on_Tree_nothing_selected"]


### PR DESCRIPTION
Fix focusing on ScriptEditor not expanding tree.
When using the shortcut over a script in the ScriptEditor, it stopped at the TabContainer and didn't go all the way to the CodeEdit. The plugin must be enabled when the Editor is opened / reloaded for this to happen.
The TabContainer had one child (its TabBar) represented in the TreeItems, so it hit the collapsed check and the branch was never updated to include its other children.
Now focusing on a Node always updates the TreeItems along the path to it. The collapsed check is skipped and only the relevant branches are updated for this.

Remove debug printing.
I assumed the "Picked" print is also for debugging since the information is in the tree, but I can restore it if wanted.
- Supersedes https://github.com/Zylann/godot_editor_debugger_plugin/pull/8

Add edited scene check to _ready.
Currently, opening the dock scene in the editor and saving it adds some lines to the tscn file, since it sets up the PopupMenu.

Tested on 4.2 and 4.5.1

Also are you interested in enhancements like a checkbox to hide the highlight, or Showing in Inspector immediately updating to show the current selected item?