### PR TITLE
Fix ShowInInspector not updating inspector

### DIFF
--- a/addons/zylann.editor_debugger/dock.gd
+++ b/addons/zylann.editor_debugger/dock.gd
@@ -3,8 +3,6 @@ extends Control
 
 const Util = preload("util.gd")
 
-signal node_selected(node: Node)
-
 @onready var _popup_menu : PopupMenu = get_node("PopupMenu")
 @onready var _inspection_checkbox : CheckBox = get_node("VBoxContainer/ShowInInspectorCheckbox")
 @onready var _label : Label = get_node("VBoxContainer/Label")
@@ -194,7 +192,31 @@ func _select_node() -> void:
 	
 	_highlight_node(node)
 	
-	emit_signal("node_selected", node)
+	if _inspection_checkbox.button_pressed:
+		_inspect_object(node)
+
+
+func _on_ShowInInspectorCheckbox_toggled(button_pressed: bool) -> void:
+	if Util.is_in_edited_scene(self):
+		return
+	if not button_pressed:
+		return
+	var node_view := _tree_view.get_selected()
+	var node := _get_node_from_view(node_view)
+	_inspect_object(node)
+
+
+func _inspect_object(node: Node) -> void:
+	if _is_under_editor_inspector(node):
+		# Prevent inspecting the inspector, because unfortunately it can crash.
+		# Something inside Godot is not handling well the possibility that what is inspected
+		# could be freed anytime.
+		return
+	EditorInterface.inspect_object(node, "", true)
+
+
+func _is_under_editor_inspector(node: Node) -> bool:
+	return Util.get_node_in_parents(node, EditorInspector) != null
 
 
 func _on_Tree_item_selected() -> void:
@@ -308,10 +330,6 @@ func pick(mpos: Vector2) -> void:
 		_highlight_node(null)
 
 
-func is_inspection_enabled() -> bool:
-	return _inspection_checkbox.button_pressed
-
-
 func _pick(root: Node, mpos: Vector2, level := 0) -> Node:
 #	var s := ""
 #	for i in level:
@@ -380,10 +398,6 @@ static func restore_ownership(root: Node, owners: Dictionary, include_internal: 
 		else:
 			child.set_owner(null)
 		restore_ownership(child, owners, include_internal)
-
-
-func _on_ShowInInspectorCheckbox_toggled(_unused_button_pressed: bool) -> void:
-	pass
 
 
 func _on_popup_menu_id_pressed(id: int) -> void:

--- a/addons/zylann.editor_debugger/dock.gd
+++ b/addons/zylann.editor_debugger/dock.gd
@@ -319,6 +319,11 @@ func _input(event: InputEvent) -> void:
 	if event_key != null and event_key.pressed:
 		if event_key.keycode == KEY_F12:
 			pick(get_viewport().get_mouse_position())
+	
+	var event_mouse_button := event as InputEventMouseButton
+	if event_mouse_button != null and event_mouse_button.pressed:
+		if event_mouse_button.button_index in [MOUSE_BUTTON_LEFT, MOUSE_BUTTON_MIDDLE, MOUSE_BUTTON_RIGHT]:
+			_control_highlighter.hide()
 
 
 func pick(mpos: Vector2) -> void:

--- a/addons/zylann.editor_debugger/dock.tscn
+++ b/addons/zylann.editor_debugger/dock.tscn
@@ -25,6 +25,7 @@ text = "Show in inspector"
 [node name="Tree" type="Tree" parent="VBoxContainer"]
 layout_mode = 2
 size_flags_vertical = 3
+allow_reselect = true
 allow_rmb_select = true
 
 [node name="Label" type="Label" parent="VBoxContainer"]

--- a/addons/zylann.editor_debugger/plugin.gd
+++ b/addons/zylann.editor_debugger/plugin.gd
@@ -4,14 +4,12 @@ extends EditorPlugin
 const DockScene = preload("dock.tscn")
 
 const Dock = preload("dock.gd")
-const Util = preload("util.gd")
 
 var _dock: Dock = null
 
 
 func _enter_tree() -> void:
 	_dock = DockScene.instantiate()
-	_dock.node_selected.connect(_on_EditorDebugger_node_selected)
 	add_control_to_dock(DOCK_SLOT_RIGHT_UL, _dock)
 	
 	#var editor_settings := get_editor_interface().get_editor_settings()
@@ -21,18 +19,3 @@ func _exit_tree() -> void:
 	remove_control_from_docks(_dock)
 	_dock.free()
 	_dock = null
-
-
-func _on_EditorDebugger_node_selected(node: Node) -> void:
-	if _dock.is_inspection_enabled():
-		if _is_under_editor_inspector(node):
-			# Prevent inspecting the inspector, because unfortunately it can crash.
-			# Something inside Godot is not handling well the possibility that what is inspected
-			# could be freed anytime.
-			return
-		# Oops.
-		EditorInterface.inspect_object(node)
-
-
-func _is_under_editor_inspector(node: Node) -> bool:
-	return Util.get_node_in_parents(node, EditorInspector) != null


### PR DESCRIPTION
The show in inspector checkbox was already connected but the callback was empty. I moved it next to `_select_node` since they are similar.

When the editor was set to 3D and you selected a Control in the tree, the editor switched to 2D because the `inspect_object` `inspector_only` parameter defaults to false and the editor was trying to edit it, but it should be set to true.
Since `inspect_object` is static it doesn't have to be called from the plugin script and the signal isn't needed.

`allow_reselect` allows clicking on a node that is already selected, this is useful in case the inspector was changed to something else.

Also the highlighter now hides on mouse click. I checked the 3 mouse buttons so it doesn't happen on scroll wheel.